### PR TITLE
Added intra-thread backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ the requirements are:
 - gem 'sass'
 - gem 'mini_magick'
 - gem 'rack_csrf'
+- gem 'mimemagic'
 
 screenshot
 ----------

--- a/views/yarn.slim
+++ b/views/yarn.slim
@@ -43,7 +43,7 @@ main#thread
             | &#8470;
           a.num.postnum =< reply.number
 
-        hr: .body: p = reply.body
+        hr: .body: p == reply.body.sub(/\>\>(?<you>\d+)/, '<a href="#p\k<you>">>>\k<you></a>')
 
 hr
 == slim :postform, locals: { page: "/#{board.route}/thread/#{yarn.number}", yarn: true }


### PR DESCRIPTION
Linking to replies in other threads would require resolving the referenced post-number, we would need an additional route for that.